### PR TITLE
configure renovate to automatically update common-performance submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "common/common-performance"]
 	path = common/common-performance
 	url = https://github.com/hmcts/common-performance.git
+	branch = master

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -35,7 +35,7 @@ withNightlyPipeline("java", product, component) {
     loadVaultSecrets(secrets)
 
     afterAlways('checkout') {
-        sh """ git submodule update --init --recursive"""
+        sh """git submodule update --init --recursive --remote"""
     }
 
     enablePerformanceTest(timeout=30, perfGatlingAlerts=true, perfRerunOnFail=true)

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,16 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>hmcts/.github:renovate-config"
+  ],
+  "git-submodules": {
+    "enabled": true
+  },
+  "schedule": ["at any time"],
+  "packageRules": [
+    {
+      "matchManagers": ["git-submodules"],
+      "matchDepNames": ["common/common-performance"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
- configuring Jenkins to always fetch the latest common-performance master branch commit
- configuring Renovate to automatically update common-performance submodule in the repo (including auto-approve and auto-merge).