### PR TITLE
Pin Infrastructure library to 2.4.4

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -9,7 +9,7 @@ properties([
 ])
 
 
-@Library("Infrastructure")
+@Library("Infrastructure@2.4.4")
 
 def product = "prl"
 def component = "citizen-frontend"


### PR DESCRIPTION
Updates Jenkinsfile_nightly to use Infrastructure library version 2.4.4.